### PR TITLE
Fetch supported asset infos via `getStaticProps`

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -16,8 +16,16 @@ import Switch from "@/components/AppSwitch";
 import Wallet from "@/components/Wallet";
 import SupportedAssetsProvider from "@/providers/SupportedAssetsProvider";
 import BlockchainProvider from "@/providers/BlockchainProvider";
+import { GlobalProps } from "@/utils/generateGlobalProps";
 
-function MyApp({ Component, pageProps }: AppProps) {
+type MyAppProps = Omit<AppProps, "pageProps"> & {
+	pageProps: {} & GlobalProps;
+};
+
+function MyApp({
+	Component,
+	pageProps: { supportedAssets, ...pageProps },
+}: MyAppProps) {
 	const router = useRouter();
 	const [location, setLocation] = useState<string>();
 
@@ -37,7 +45,7 @@ function MyApp({ Component, pageProps }: AppProps) {
 				<CssBaseline />
 				<CENNZApiProvider>
 					<DappModuleProvider>
-						<SupportedAssetsProvider>
+						<SupportedAssetsProvider supportedAssets={supportedAssets}>
 							<SupportedWalletProvider>
 								<Web3AccountsProvider>
 									<BlockchainProvider>

--- a/pages/bridge/index.tsx
+++ b/pages/bridge/index.tsx
@@ -12,6 +12,15 @@ import TokenPicker from "@/components/shared/TokenPicker";
 import { CHAINS, getMetamaskBalance } from "@/utils/bridge/helpers";
 import ExchangeIcon from "@/components/shared/ExchangeIcon";
 import { useWallet } from "@/providers/SupportedWalletProvider";
+import generateGlobalProps from "@/utils/generateGlobalProps";
+
+export async function getStaticProps() {
+	return {
+		props: {
+			...(await generateGlobalProps()),
+		},
+	};
+}
 
 const Emery: React.FC<{}> = () => {
 	const [bridgeState, setBridgeState] = useState<BridgeState>("Deposit");

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,17 +1,3 @@
-import React, { useEffect } from "react";
-import { useCENNZApi } from "@/providers/CENNZApiProvider";
 import Swap from "@/pages/swap";
-
-const Home: React.FC<{}> = () => {
-	const { api, initApi } = useCENNZApi();
-
-	useEffect(() => {
-		if (!api?.isConnected) {
-			initApi();
-		}
-	}, [api, initApi]);
-
-	return <Swap />;
-};
-
-export default Home;
+export default Swap;
+export { getStaticProps } from "@/pages/swap";

--- a/pages/pool/index.tsx
+++ b/pages/pool/index.tsx
@@ -3,6 +3,15 @@ import { Box } from "@mui/material";
 import PoolProvider from "@/providers/PoolProvider";
 import PoolForm from "@/components/pool/PoolForm";
 import { useCENNZApi } from "@/providers/CENNZApiProvider";
+import generateGlobalProps from "@/utils/generateGlobalProps";
+
+export async function getStaticProps() {
+	return {
+		props: {
+			...(await generateGlobalProps()),
+		},
+	};
+}
 
 const Pool: React.FC<{}> = () => {
 	const { api, initApi } = useCENNZApi();

--- a/pages/swap/index.tsx
+++ b/pages/swap/index.tsx
@@ -14,6 +14,15 @@ import {
 	fetchExchangeExtrinsic,
 	fetchTokenAmounts,
 } from "@/utils/swap";
+import generateGlobalProps from "@/utils/generateGlobalProps";
+
+export async function getStaticProps() {
+	return {
+		props: {
+			...(await generateGlobalProps()),
+		},
+	};
+}
 
 const Exchange: React.FC<{}> = () => {
 	const [exchangeToken, setExchangeToken] = useState<Asset>();

--- a/providers/SupportedAssetsProvider.tsx
+++ b/providers/SupportedAssetsProvider.tsx
@@ -1,58 +1,17 @@
-import {
-	createContext,
-	PropsWithChildren,
-	useContext,
-	useEffect,
-	useState,
-} from "react";
-import { useCENNZApi } from "@/providers/CENNZApiProvider";
-import { u8aToString } from "@polkadot/util";
-import { AssetInfo } from "@/types";
-import { ETH_LOGO } from "@/utils/bridge/helpers";
+import { createContext, PropsWithChildren, useContext } from "react";
 
-const assetIds =
-	process.env.NEXT_PUBLIC_SUPPORTED_ASSETS &&
-	process.env.NEXT_PUBLIC_SUPPORTED_ASSETS.split(",");
+import { AssetInfo } from "@/types";
 
 const SupportedAssetsContext = createContext<AssetInfo[]>([]);
 
-type ProviderProps = {};
+type ProviderProps = {
+	supportedAssets: AssetInfo[];
+};
 
 export default function SupportedAssetsProvider({
 	children,
+	supportedAssets,
 }: PropsWithChildren<ProviderProps>) {
-	const [supportedAssets, setSupportedAssets] = useState<AssetInfo[]>();
-	const { api } = useCENNZApi();
-
-	useEffect(() => {
-		if (!api) return;
-		(async () => {
-			try {
-				const assets = await (api.rpc as any).genericAsset.registeredAssets();
-				if (!assets?.length) return;
-				const assetInfos = assetIds.map((assetId) => {
-					const [tokenId, { symbol, decimalPlaces }] = assets?.find((asset) => {
-						return asset[0].toString() === assetId;
-					});
-					const logo =
-						u8aToString(symbol) === "ETH"
-							? ETH_LOGO
-							: `/images/${u8aToString(symbol).toLowerCase()}.svg`;
-					return {
-						id: Number(tokenId),
-						symbol: u8aToString(symbol),
-						decimals: decimalPlaces.toNumber(),
-						logo: logo,
-					};
-				});
-
-				setSupportedAssets(assetInfos);
-			} catch (err) {
-				console.log(err.message);
-			}
-		})();
-	}, [api]);
-
 	return (
 		<SupportedAssetsContext.Provider value={supportedAssets}>
 			{children}

--- a/public/images/eth.svg
+++ b/public/images/eth.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="256px" height="417px" viewBox="0 0 256 417" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" preserveAspectRatio="xMidYMid">
+	<g>
+		<polygon fill="#343434" points="127.9611 0 125.1661 9.5 125.1661 285.168 127.9611 287.958 255.9231 212.32"/>
+		<polygon fill="#8C8C8C" points="127.962 0 0 212.32 127.962 287.959 127.962 154.158"/>
+		<polygon fill="#3C3C3B" points="127.9611 312.1866 126.3861 314.1066 126.3861 412.3056 127.9611 416.9066 255.9991 236.5866"/>
+		<polygon fill="#8C8C8C" points="127.962 416.9052 127.962 312.1852 0 236.5852"/>
+		<polygon fill="#141414" points="127.9611 287.9577 255.9211 212.3207 127.9611 154.1587"/>
+		<polygon fill="#393939" points="0.0009 212.3208 127.9609 287.9578 127.9609 154.1588"/>
+	</g>
+</svg>

--- a/tests/fetchSupportedAssets.test.ts
+++ b/tests/fetchSupportedAssets.test.ts
@@ -17,7 +17,9 @@ describe("fetchSupportedAssets", () => {
 
 		assets.forEach((asset, index) => {
 			expect(asset.id).toStrictEqual(assetIds[index]);
-			expect(asset.logo).toStrictEqual(`images/${asset.symbol}.svg`);
+			expect(asset.logo).toStrictEqual(
+				`images/${asset.symbol.toLowerCase()}.svg`
+			);
 		});
 	});
 

--- a/tests/fetchSupportedAssets.test.ts
+++ b/tests/fetchSupportedAssets.test.ts
@@ -1,0 +1,30 @@
+import { Api } from "@cennznet/api";
+import fetchSupportedAssets from "@/utils/fetchSupportedAssets";
+
+describe("fetchSupportedAssets", () => {
+	let api: Api;
+	beforeAll(async () => {
+		api = await Api.create({ provider: "wss://nikau.centrality.me/public/ws" });
+	});
+
+	afterAll(async () => {
+		await api.disconnect();
+	});
+
+	it("returns list of assets with their infos", async () => {
+		const assetIds = [16000, 16001, 17002];
+		const assets = await fetchSupportedAssets(api, assetIds);
+
+		assets.forEach((asset, index) => {
+			expect(asset.id).toStrictEqual(assetIds[index]);
+			expect(asset.logo).toStrictEqual(`images/${asset.symbol}.svg`);
+		});
+	});
+
+	it("throws error if any of requested `assetId` doesn not exist", async () => {
+		const assetIds = [10000];
+		await expect(fetchSupportedAssets(api, assetIds)).rejects.toThrow(
+			'Asset id "10000" not found'
+		);
+	});
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -207,7 +207,7 @@ export interface AssetInfo {
 	id: number;
 	symbol: string;
 	decimals: number;
-	existentialDeposit?: number;
+	logo: string;
 }
 
 export interface PoolValues {

--- a/utils/bridge/helpers.ts
+++ b/utils/bridge/helpers.ts
@@ -3,8 +3,7 @@ import GenericERC20TokenAbi from "@/artifacts/GenericERC20Token.json";
 import { Chain } from "@/types";
 
 export const ETH = "0x0000000000000000000000000000000000000000";
-export const ETH_LOGO =
-	"https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png";
+export const ETH_LOGO = `images/eth.svg`;
 
 export const CHAINS: Chain[] = [
 	{

--- a/utils/fetchSupportedAssets.ts
+++ b/utils/fetchSupportedAssets.ts
@@ -1,0 +1,29 @@
+import { Api } from "@cennznet/api";
+import { AssetInfo } from "@/types";
+import { u8aToString } from "@polkadot/util";
+
+export default async function fetchSupportedAssets(
+	api: Api,
+	assetIds: number[]
+): Promise<Array<AssetInfo>> {
+	const assets = await (api.rpc as any).genericAsset.registeredAssets();
+	if (!assets?.length) return [];
+	return assetIds
+		.map((assetId) => {
+			const [tokenId, { symbol, decimalPlaces }] = assets.find((asset: any) => {
+				return Number(asset[0]) === assetId;
+			}) || [null, {}];
+
+			if (!tokenId) throw new Error(`Asset id "${assetId}" not found`);
+
+			const symbolString = u8aToString(symbol);
+
+			return {
+				id: Number(tokenId),
+				symbol: symbolString,
+				decimals: decimalPlaces.toNumber(),
+				logo: `images/${symbolString}.svg`,
+			};
+		})
+		.filter(Boolean);
+}

--- a/utils/fetchSupportedAssets.ts
+++ b/utils/fetchSupportedAssets.ts
@@ -22,7 +22,7 @@ export default async function fetchSupportedAssets(
 				id: Number(tokenId),
 				symbol: symbolString,
 				decimals: decimalPlaces.toNumber(),
-				logo: `images/${symbolString}.svg`,
+				logo: `images/${symbolString.toLowerCase()}.svg`,
 			};
 		})
 		.filter(Boolean);

--- a/utils/generateGlobalProps.ts
+++ b/utils/generateGlobalProps.ts
@@ -1,0 +1,17 @@
+import { Api } from "@cennznet/api";
+import { AssetInfo } from "@/types";
+import fetchSupportedAssets from "@/utils/fetchSupportedAssets";
+
+export type GlobalProps = {
+	supportedAssets: AssetInfo[];
+};
+
+export default async function generateGlobalProps(): Promise<GlobalProps> {
+	const api = await Api.create({ provider: process.env.NEXT_PUBLIC_API_URL });
+
+	const supportedAssetIds =
+		process.env.NEXT_PUBLIC_SUPPORTED_ASSETS.split(",").map(Number);
+	return {
+		supportedAssets: await fetchSupportedAssets(api, supportedAssetIds),
+	};
+}


### PR DESCRIPTION
## Description

Move asset infos fetching to `getStaticProps` to improve start-up time

## Details

#### Changes

- Use proper Etherium SVG logo
- Update `SupportedAssetsProvider` to use supported assets data from `getInitialProps`

### Removes

- Remove code-duplicate in `pages/index.tsx`, re-export from `pages/swap/index.tsx` instead

#### Adds

- Integration testing for supported assets fetching