### PR TITLE
ensure chain if user has previously connected but switched networks

### DIFF
--- a/providers/MetaMaskWalletProvider.tsx
+++ b/providers/MetaMaskWalletProvider.tsx
@@ -66,6 +66,7 @@ const MetaMaskWalletProvider: FC<MetaMaskWalletProviderProps> = ({
 
 			setSelectedAccount({ address: accounts[0] });
 			setWallet(new ethers.providers.Web3Provider(extension as any));
+			await ensureEthereumChain(extension);
 		};
 
 		checkAccounts();


### PR DESCRIPTION
## Description

 - call `ensureEthereumChain()` in `checkAccounts` useEffect