### PR TITLE
Add confirming state to the Bridge

### DIFF
--- a/components/BridgeForm.tsx
+++ b/components/BridgeForm.tsx
@@ -75,7 +75,8 @@ const BridgeForm: FC<IntrinsicElements["form"] & BridgeFormProps> = ({
 				metaMaskWallet.getSigner()
 			);
 
-			if (tx !== "cancelled") await ensureRelayerDepositDone(tx.hash);
+			if (tx !== "cancelled")
+				await ensureRelayerDepositDone(tx.hash, 600000, setProgressStatus);
 		} catch (error) {
 			console.info(error);
 			return setFailStatus(error?.code);

--- a/components/BridgeForm.tsx
+++ b/components/BridgeForm.tsx
@@ -115,6 +115,7 @@ const BridgeForm: FC<IntrinsicElements["form"] & BridgeFormProps> = ({
 		try {
 			await ensureEthereumChain(extension);
 			await ensureBridgeWithdrawActive(api, metaMaskWallet);
+			setProgressStatus("CennznetConfirming");
 			eventProof = await sendWithdrawCENNZRequest(
 				api,
 				transferAmount,
@@ -132,6 +133,7 @@ const BridgeForm: FC<IntrinsicElements["form"] & BridgeFormProps> = ({
 
 		let tx: Awaited<ReturnType<typeof sendWithdrawEthereumRequest>>;
 		try {
+			setProgressStatus("EthereumConfirming");
 			tx = await sendWithdrawEthereumRequest(
 				api,
 				eventProof,
@@ -183,6 +185,7 @@ const BridgeForm: FC<IntrinsicElements["form"] & BridgeFormProps> = ({
 
 		let tx: Awaited<ReturnType<typeof sendWithdrawEthereumRequest>>;
 		try {
+			setProgressStatus("EthereumConfirming");
 			tx = await sendWithdrawEthereumRequest(
 				api,
 				eventProof,

--- a/components/BridgeProgress.tsx
+++ b/components/BridgeProgress.tsx
@@ -114,6 +114,11 @@ const styles = {
 			font-weight: bold;
 			font-style: normal;
 			color: ${palette.primary.main};
+			font-size: 0.5em;
+			span {
+				font-size: 2em;
+				letter-spacing: -0.025em;
+			}
 		}
 	`,
 

--- a/providers/BridgeProvider.tsx
+++ b/providers/BridgeProvider.tsx
@@ -5,9 +5,10 @@ import {
 	BridgeAction,
 	BridgedEthereumToken,
 	EthereumToken,
+	RelayerConfirmingStatus,
 	TxStatus,
 } from "@/types";
-import { Balance } from "@/utils";
+import { Balance, selectMap } from "@/utils";
 import {
 	createContext,
 	Dispatch,
@@ -42,7 +43,7 @@ interface BridgeContextType {
 	txStatus: TxStatus;
 	setTxStatus: Dispatch<SetStateAction<TxStatus>>;
 
-	setProgressStatus: () => void;
+	setProgressStatus: (status?: RelayerConfirmingStatus) => void;
 	setSuccessStatus: () => void;
 	setFailStatus: (errorCode?: string) => void;
 
@@ -91,10 +92,21 @@ const BridgeProvider: FC<BridgeProviderProps> = ({
 
 	const [txStatus, setTxStatus] = useState<TxStatus>(null);
 
-	const setProgressStatus = useCallback(() => {
+	const setProgressStatus = useCallback((status?: RelayerConfirmingStatus) => {
+		const title = selectMap<RelayerConfirmingStatus, string>(
+			status,
+			new Map([
+				["EthereumConfirming", "Confirming on Ethereum"],
+				["CennznetConfirming", "Confirming on CENNZnet"],
+			]),
+			"Transaction In Progress"
+		);
+
+		console.log(title);
+
 		setTxStatus({
 			status: "in-progress",
-			title: "Transaction In Progress",
+			title,
 			message: (
 				<div>
 					Please sign the transaction when prompted and wait until it&apos;s

--- a/providers/BridgeProvider.tsx
+++ b/providers/BridgeProvider.tsx
@@ -137,7 +137,7 @@ const BridgeProvider: FC<BridgeProviderProps> = ({
 						You successfully withdrew{" "}
 						<pre>
 							<em>
-								{trValue} {trSymbol}
+								<span>{trValue}</span> <span>{trSymbol}</span>
 							</em>
 						</pre>{" "}
 						from CENNZnet.
@@ -151,7 +151,7 @@ const BridgeProvider: FC<BridgeProviderProps> = ({
 						You successfully deposited{" "}
 						<pre>
 							<em>
-								{trValue} {trSymbol}
+								<span>{trValue}</span> <span>{trSymbol}</span>
 							</em>
 						</pre>{" "}
 						to CENNZnet.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -77,3 +77,15 @@ export interface TxStatus {
 	title: string;
 	message: string | ReactElement;
 }
+
+export type RelayerStatus =
+	| "Successful"
+	| "Failed"
+	| "Confirming"
+	| "EthereumConfirming"
+	| "CennznetConfirming";
+
+export type RelayerConfirmingStatus = Extract<
+	RelayerStatus,
+	"EthereumConfirming" | "CennznetConfirming"
+>;

--- a/utils/fetchDepositRelayerStatus.ts
+++ b/utils/fetchDepositRelayerStatus.ts
@@ -1,20 +1,16 @@
 import { BRIDGE_RELAYER_URL } from "@/constants";
-
-type RelayerStatus = "Successful" | "Failed" | "Confirming";
+import { RelayerStatus } from "@/types";
 
 // TODO: Needs test
 export default async function fetchDepositRelayerStatus(
 	txHash: string
 ): Promise<RelayerStatus> {
-	const response = await fetch(
+	const relayerResponse = await fetch(
 		`${BRIDGE_RELAYER_URL}/transactions/${txHash}`
 	).then((response) => {
 		if (response.status !== 200) throw { code: `RELAYER_${response.status}` };
 		return response.json();
 	});
 
-	if (response.status === "Successful" || response.status === "Failed")
-		return response.status;
-
-	return "Confirming";
+	return relayerResponse.status;
 }

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -37,3 +37,4 @@ export { default as ensureRelayerDepositDone } from "@/utils/ensureRelayerDeposi
 export { default as sendWithdrawEthereumRequest } from "@/utils/sendWithdrawEthereumRequest";
 export { default as trackPageView } from "@/utils/trackPageView";
 export { default as getSellAssetExtrinsic } from "@/utils/getSellAssetExtrinsic";
+export { default as selectMap } from "@/utils/selectMap";

--- a/utils/selectMap.ts
+++ b/utils/selectMap.ts
@@ -1,0 +1,16 @@
+/**
+ * A utility that return value by key from a map
+ *
+ * @param {K} key
+ * @param {Map<K, V>} map
+ * @param {V} defaultValue
+ * @return {V}
+ */
+export default function selectMap<K, V>(
+	key: K,
+	map: Map<K, V>,
+	defaultValue?: V
+): V {
+	if (!map.has(key)) return defaultValue;
+	return map.get(key);
+}


### PR DESCRIPTION
## Description

Show some activities during the transaction "in-progress" state. It will now show "Confirming on Ethereum" / "Confirming on CENNZnet" effectively for both Deposit and Withdraw (including Historical Withdraw)

## Details

#### Changes

- Add confirming states to `in-progress` panel
- Increase wait timeout for the relayer to 10 minutes
- Close up the gap between `value` and `symbol` in the Success state

## Notes

This supersedes #148 