### PR TITLE
Fix mixed up claiming address

### DIFF
--- a/components/BridgeUnclaimedWithdrawals.tsx
+++ b/components/BridgeUnclaimedWithdrawals.tsx
@@ -27,7 +27,7 @@ const BridgeUnclaimedWithdrawals: VFC = () => {
 		<TableContainer css={styles.container}>
 			<Table>
 				<TableHead>
-					<TableRow>
+					<TableRow css={styles.rowHead}>
 						<TableCell css={styles.column}>ID</TableCell>
 						<TableCell css={styles.column}>Entry</TableCell>
 						<TableCell css={styles.column}>Action</TableCell>
@@ -125,20 +125,20 @@ const EntryCell: VFC<{ withdrawClaim: WithdrawClaim }> = ({
 };
 
 const styles = {
-	container: css`
-		margin-top: 0.2em;
-		border: 1px solid rgba(0, 0, 0, 0.1);
+	container: ({ palette }: Theme) => css`
+		border: 1px solid ${palette.text.secondary};
 		border-radius: 4px;
 		overflow-y: auto;
 		white-space: nowrap;
 		max-height: 15em;
 	`,
 
-	column: css`
+	column: ({ palette }: Theme) => css`
 		text-align: center;
+		border-bottom: 1px solid ${palette.grey["200"]};
 	`,
 
-	columnMain: ({ palette }: Theme) => css`
+	columnMain: css`
 		text-align: left;
 
 		em {
@@ -155,8 +155,9 @@ const styles = {
 
 	row: ({ palette, transitions }: Theme) => css`
 		transition: background-color ${transitions.duration.shortest}ms;
+
 		&:nth-of-type(even) {
-			background-color: rgba(0, 0, 0, 0.03);
+			background-color: rgba(0, 0, 0, 0.01);
 		}
 
 		&:last-of-type {
@@ -196,6 +197,13 @@ const styles = {
 	rowEmpty: css`
 		td {
 			text-align: center;
+		}
+	`,
+
+	rowHead: ({ palette }: Theme) => css`
+		background-color: ${palette.grey["200"]};
+		th {
+			padding: 0.5em;
 		}
 	`,
 

--- a/hooks/useHistoricalWithdrawRequest.ts
+++ b/hooks/useHistoricalWithdrawRequest.ts
@@ -59,7 +59,7 @@ export default function useHistoricalWithdrawRequest(): (
 					eventProof,
 					unclaimed.transferAmount,
 					unclaimed.transferAsset,
-					transferMetaMaskAddress,
+					unclaimed.beneficiary,
 					metaMaskWallet.getSigner(),
 					eventProof.blockHash
 				)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -95,4 +95,5 @@ export interface WithdrawClaim {
 	eventProofId: number;
 	transferAsset: BridgedEthereumToken;
 	transferAmount: Balance;
+	beneficiary: string;
 }

--- a/utils/fetchUnclaimedWithdrawals.ts
+++ b/utils/fetchUnclaimedWithdrawals.ts
@@ -47,6 +47,7 @@ export default async function fetchUnclaimedWithdrawals(
 				eventProofId: Number(withdrawal.proofId),
 				transferAsset: transferAsset as BridgedEthereumToken,
 				transferAmount,
+				beneficiary: withdrawal.beneficiary,
 			};
 		})
 	);


### PR DESCRIPTION
## Description

Use `beneficiary` as address to initiate the historical withdraw request

## Details

#### Changes

- Add `beneficiary` to `WithdrawClaim` object
- Combine Value / Beneficiary / Expiry into one cell
- Tweak styling of the withdraws table

![Screen Shot 2022-04-20 at 20 21 26](https://user-images.githubusercontent.com/97480229/164184066-55490fc3-8c89-40d6-8294-cd6583945824.png)

