### PR TITLE
Update styling post MetaMask integration

### DIFF
--- a/components/BridgeActionsPair.tsx
+++ b/components/BridgeActionsPair.tsx
@@ -23,7 +23,7 @@ const BridgeActionsPair: VFC<
 		},
 	];
 
-	const { setBridgeAction, updateMetaMaskBalances } = useBridge();
+	const { setBridgeAction, updateEthereumBalances } = useBridge();
 
 	const [fromOption, setFromOption] = useState<string>("Ethereum");
 	const [toOption, setToOption] = useState<string>("CENNZnet");
@@ -70,12 +70,12 @@ const BridgeActionsPair: VFC<
 
 	useEffect(() => {
 		if (!fromOption) return;
-		if (fromOption === "Ethereum") return updateMetaMaskBalances?.();
+		if (fromOption === "Ethereum") return updateEthereumBalances?.();
 		if (fromOption === "CENNZnet") {
 			void updateCENNZBalances?.();
 			return;
 		}
-	}, [fromOption, updateMetaMaskBalances, updateCENNZBalances]);
+	}, [fromOption, updateEthereumBalances, updateCENNZBalances]);
 
 	return (
 		<div {...props} css={styles.root}>

--- a/components/BridgeTokenDestination.tsx
+++ b/components/BridgeTokenDestination.tsx
@@ -115,6 +115,9 @@ const BridgeTokenDestination: VFC<
 						Balance: <LinearProgress css={[styles.formInfoProgress]} />
 					</div>
 				)}
+				{transferBalance === null && (!metaMaskAccount || !cennzAccount) && (
+					<div css={styles.tokenBalance}>Balance: 0.0</div>
+				)}
 			</div>
 			{bridgeAction === "Deposit" && (
 				<div css={styles.formField}>

--- a/components/BridgeTokenDestination.tsx
+++ b/components/BridgeTokenDestination.tsx
@@ -27,7 +27,7 @@ const BridgeTokenDestination: VFC<
 		setTransferCENNZAddress,
 		transferMetaMaskAddress,
 		setTransferMetaMaskAddress,
-		metaMaskBalance,
+		ethereumBalance,
 		advancedExpanded,
 	} = useBridge();
 	const { selectedWallet } = useWalletProvider();
@@ -37,7 +37,7 @@ const BridgeTokenDestination: VFC<
 	);
 
 	const transferBalance =
-		bridgeAction === "Withdraw" ? cennzBalance : metaMaskBalance;
+		bridgeAction === "Withdraw" ? cennzBalance : ethereumBalance;
 
 	const onTransferMaxRequest = useMemo(() => {
 		const setErc20Value = transferInput.setValue;

--- a/components/PoolForm.tsx
+++ b/components/PoolForm.tsx
@@ -52,7 +52,7 @@ const PoolForm: FC<IntrinsicElements["form"] & PoolFormProps> = ({
 		updateExchangeRate,
 	} = usePool();
 
-	const { selectedAccount: CENNZAccount, wallet } = useCENNZWallet();
+	const { selectedAccount: cennzAccount, wallet } = useCENNZWallet();
 	const { selectedAccount: metaMaskAccount } = useMetaMaskWallet();
 	const { extension } = useMetaMaskExtension();
 
@@ -108,7 +108,7 @@ const PoolForm: FC<IntrinsicElements["form"] & PoolFormProps> = ({
 				if (selectedWallet === "CENNZnet")
 					tx = await signAndSendTx(
 						extrinsic as SubmittableExtrinsic<"promise">,
-						CENNZAccount.address,
+						cennzAccount.address,
 						wallet.signer
 					);
 				if (selectedWallet === "MetaMask")
@@ -170,7 +170,7 @@ const PoolForm: FC<IntrinsicElements["form"] & PoolFormProps> = ({
 			updatePoolUserInfo,
 			updateExchangeRate,
 			api,
-			CENNZAccount?.address,
+			cennzAccount?.address,
 			metaMaskAccount?.address,
 			wallet?.signer,
 			coreAsset,

--- a/components/SwapForm.tsx
+++ b/components/SwapForm.tsx
@@ -41,7 +41,7 @@ const SwapForm: FC<IntrinsicElements["form"] & SwapFormProps> = ({
 		setTxSuccess,
 		setTxFailure,
 	} = useSwap();
-	const { selectedAccount: CENNZAccount, wallet } = useCENNZWallet();
+	const { selectedAccount: cennzAccount, wallet } = useCENNZWallet();
 	const { selectedAccount: metaMaskAccount } = useMetaMaskWallet();
 	const { extension } = useMetaMaskExtension();
 
@@ -68,7 +68,7 @@ const SwapForm: FC<IntrinsicElements["form"] & SwapFormProps> = ({
 				if (selectedWallet === "CENNZnet")
 					tx = await signAndSendTx(
 						extrinsic as SubmittableExtrinsic<"promise">,
-						CENNZAccount.address,
+						cennzAccount.address,
 						wallet.signer
 					);
 				if (selectedWallet === "MetaMask")
@@ -119,7 +119,7 @@ const SwapForm: FC<IntrinsicElements["form"] & SwapFormProps> = ({
 			exValue,
 			reValue,
 			slippage,
-			CENNZAccount?.address,
+			cennzAccount?.address,
 			metaMaskAccount?.address,
 			wallet?.signer,
 			updateCENNZBalances,

--- a/components/Wallet.tsx
+++ b/components/Wallet.tsx
@@ -42,6 +42,11 @@ const Wallet: FC = () => {
 	}, [updateCENNZBalances, walletOpen]);
 
 	useEffect(() => {
+		if (!metaMaskAccount?.address) return;
+		setBalanceListHeight(0);
+	}, [metaMaskAccount?.address]);
+
+	useEffect(() => {
 		if (!walletOpen) return;
 		const setListHeight = () => {
 			const balanceList = ref.current;

--- a/components/Wallet.tsx
+++ b/components/Wallet.tsx
@@ -14,7 +14,7 @@ import { InjectedAccountWithMeta } from "@polkadot/extension-inject/types";
 
 const Wallet: FC = () => {
 	const {
-		CENNZBalances,
+		cennzBalances,
 		setWalletOpen,
 		walletOpen,
 		selectedWallet,
@@ -39,7 +39,7 @@ const Wallet: FC = () => {
 		if (!walletOpen) return;
 		const setListHeight = () => {
 			const balanceList = ref.current;
-			if (!balanceList || !CENNZBalances?.length)
+			if (!balanceList || !cennzBalances?.length)
 				return setBalanceListHeight(0);
 			const rect = balanceList.getBoundingClientRect();
 			setBalanceListHeight(rect.height);
@@ -49,7 +49,7 @@ const Wallet: FC = () => {
 		setListHeight();
 
 		return () => clearTimeout(id);
-	}, [CENNZBalances, walletOpen]);
+	}, [cennzBalances, walletOpen]);
 
 	const onAccountSelect = useCallback(
 		(event) => {
@@ -129,30 +129,32 @@ const Wallet: FC = () => {
 				]}
 			>
 				<div css={styles.accountBalances} ref={ref}>
-					{!!CENNZBalances?.length && (
+					{!!cennzBalances?.length && (
 						<>
 							<div css={styles.balanceHeading}>Balance</div>
 
 							<ul css={styles.balanceList}>
-								{CENNZBalances.filter(
-									(asset) =>
-										asset.value.gt(0) ||
-										[CENNZ_ASSET_ID, CPAY_ASSET_ID].includes(asset.assetId)
-								).map((asset) => {
-									const logo = getTokenLogo(asset.symbol);
+								{cennzBalances
+									.filter(
+										(asset) =>
+											asset.value.gt(0) ||
+											[CENNZ_ASSET_ID, CPAY_ASSET_ID].includes(asset.assetId)
+									)
+									.map((asset) => {
+										const logo = getTokenLogo(asset.symbol);
 
-									return (
-										<li key={asset.assetId} css={styles.balanceItem}>
-											<figure>
-												{logo && (
-													<img src={logo.src} alt={`${asset.symbol}-logo`} />
-												)}
-											</figure>
-											<span>{asset.value.toBalance()}</span>
-											<label>{asset.symbol}</label>
-										</li>
-									);
-								})}
+										return (
+											<li key={asset.assetId} css={styles.balanceItem}>
+												<figure>
+													{logo && (
+														<img src={logo.src} alt={`${asset.symbol}-logo`} />
+													)}
+												</figure>
+												<span>{asset.value.toBalance()}</span>
+												<label>{asset.symbol}</label>
+											</li>
+										);
+									})}
 							</ul>
 						</>
 					)}

--- a/components/Wallet.tsx
+++ b/components/Wallet.tsx
@@ -215,6 +215,7 @@ export const styles = {
 		line-height: 1;
 		opacity: 0.7;
 		cursor: copy;
+		font-family: "Roboto Mono", monospace;
 	`,
 
 	switchAccount: ({ palette }: Theme) => css`

--- a/components/Wallet.tsx
+++ b/components/Wallet.tsx
@@ -9,7 +9,7 @@ import getTokenLogo from "@/utils/getTokenLogo";
 import { CENNZ_ASSET_ID, CPAY_ASSET_ID } from "@/constants";
 import { useWalletProvider } from "@/providers/WalletProvider";
 import { useMetaMaskWallet } from "@/providers/MetaMaskWalletProvider";
-import { useSelectedAccount } from "@/hooks";
+import { useSelectedAccount, useUpdateCENNZBalances } from "@/hooks";
 import { InjectedAccountWithMeta } from "@polkadot/extension-inject/types";
 
 const Wallet: FC = () => {
@@ -24,6 +24,7 @@ const Wallet: FC = () => {
 	const { accounts } = useCENNZExtension();
 	const { selectedAccount: metaMaskAccount } = useMetaMaskWallet();
 	const selectedAccount = useSelectedAccount();
+	const updateCENNZBalances = useUpdateCENNZBalances();
 
 	const onWalletDisconnect = useCallback(() => {
 		setWalletOpen(false);
@@ -34,6 +35,11 @@ const Wallet: FC = () => {
 
 	const ref = useRef<HTMLDivElement>();
 	const [balanceListHeight, setBalanceListHeight] = useState<number>(0);
+
+	useEffect(() => {
+		if (!walletOpen) return;
+		updateCENNZBalances?.();
+	}, [updateCENNZBalances, walletOpen]);
 
 	useEffect(() => {
 		if (!walletOpen) return;

--- a/components/WalletButton.tsx
+++ b/components/WalletButton.tsx
@@ -3,7 +3,7 @@ import { css } from "@emotion/react";
 import { useCENNZWallet } from "@/providers/CENNZWalletProvider";
 import WalletModal from "@/components/WalletModal";
 import AccountIdenticon from "@/components/shared/AccountIdenticon";
-import CENNZIconSVG from "@/assets/vectors/cennznet-icon.svg";
+import AccountBalanceWalletIcon from "@mui/icons-material/AccountBalanceWallet";
 import { Theme } from "@mui/material";
 import WalletSelect from "@/components/WalletSelect";
 import Wallet from "@/components/Wallet";
@@ -31,11 +31,7 @@ const WalletButton: React.FC = () => {
 			>
 				<div css={styles.walletIcon}>
 					{(walletState === "NotConnected" || !selectedWallet) && (
-						<img
-							src={CENNZIconSVG.src}
-							alt="CENNZnet Logo"
-							css={styles.walletIconImg}
-						/>
+						<AccountBalanceWalletIcon css={styles.walletIconImg} />
 					)}
 
 					{!!cennzAccount?.address && selectedWallet === "CENNZnet" && (
@@ -91,8 +87,8 @@ export const styles = {
 				height: 48px;
 				display: flex;
 				align-items: center;
-				background-color: ${walletOpen ? palette.primary.default : "#FFFFFF"};
-				color: ${walletOpen ? "#FFFFFF !important" : palette.primary.default};
+				background-color: ${walletOpen ? palette.primary.main : "#FFFFFF"};
+				color: ${walletOpen ? "#FFFFFF !important" : palette.primary.main};
 				transition: background-color ${transitions.duration.short}ms,
 					color ${transitions.duration.short}ms;
 				border-radius: 4px;
@@ -101,7 +97,7 @@ export const styles = {
 				max-width: 240px;
 
 				&:hover {
-					background-color: ${palette.primary.default};
+					background-color: ${palette.primary.main};
 					color: white;
 				}
 			`,
@@ -109,7 +105,7 @@ export const styles = {
 	walletIcon: css`
 		width: 28px;
 		height: 28px;
-		margin-right: 0.5em;
+		margin-right: 0.75em;
 		position: relative;
 	`,
 

--- a/components/WalletButton.tsx
+++ b/components/WalletButton.tsx
@@ -15,13 +15,13 @@ type WalletState = "Connected" | "NotConnected";
 
 const WalletButton: React.FC = () => {
 	const { walletOpen, setWalletOpen, selectedWallet } = useWalletProvider();
-	const { selectedAccount: CENNZAccount } = useCENNZWallet();
+	const { selectedAccount: cennzAccount } = useCENNZWallet();
 	const { selectedAccount: metaMaskAccount } = useMetaMaskWallet();
 
 	const walletState = useMemo<WalletState>(() => {
 		if (!!selectedWallet) return "Connected";
-		if (!CENNZAccount || !metaMaskAccount) return "NotConnected";
-	}, [CENNZAccount, metaMaskAccount, selectedWallet]);
+		if (!cennzAccount || !metaMaskAccount) return "NotConnected";
+	}, [cennzAccount, metaMaskAccount, selectedWallet]);
 
 	return (
 		<>
@@ -38,12 +38,12 @@ const WalletButton: React.FC = () => {
 						/>
 					)}
 
-					{!!CENNZAccount?.address && selectedWallet === "CENNZnet" && (
+					{!!cennzAccount?.address && selectedWallet === "CENNZnet" && (
 						<AccountIdenticon
 							css={styles.walletIconIdenticon}
 							theme="beachball"
 							size={28}
-							value={CENNZAccount.address}
+							value={cennzAccount.address}
 						/>
 					)}
 					{!!metaMaskAccount?.address && selectedWallet === "MetaMask" && (
@@ -56,7 +56,7 @@ const WalletButton: React.FC = () => {
 
 				<div css={styles.walletState}>
 					{walletState === "Connected" && selectedWallet === "CENNZnet" && (
-						<span>{CENNZAccount?.meta?.name?.toUpperCase?.()}</span>
+						<span>{cennzAccount?.meta?.name?.toUpperCase?.()}</span>
 					)}
 					{walletState === "Connected" && selectedWallet === "MetaMask" && (
 						<span>

--- a/components/WalletButton.tsx
+++ b/components/WalletButton.tsx
@@ -28,8 +28,6 @@ const WalletButton: React.FC = () => {
 		return "NotConnected";
 	}, [cennzAccount?.address, metaMaskAccount?.address, selectedWallet]);
 
-	console.log({ walletState });
-
 	return (
 		<>
 			<div

--- a/components/WalletButton.tsx
+++ b/components/WalletButton.tsx
@@ -11,7 +11,7 @@ import { useWalletProvider } from "@/providers/WalletProvider";
 import { useMetaMaskWallet } from "@/providers/MetaMaskWalletProvider";
 import Jazzicon, { jsNumberForAddress } from "react-jazzicon";
 
-type WalletState = "Connected" | "NotConnected";
+type WalletState = "Connected" | "Connecting" | "NotConnected";
 
 const WalletButton: React.FC = () => {
 	const { walletOpen, setWalletOpen, selectedWallet } = useWalletProvider();
@@ -19,9 +19,16 @@ const WalletButton: React.FC = () => {
 	const { selectedAccount: metaMaskAccount } = useMetaMaskWallet();
 
 	const walletState = useMemo<WalletState>(() => {
-		if (!!selectedWallet) return "Connected";
-		if (!cennzAccount || !metaMaskAccount) return "NotConnected";
-	}, [cennzAccount, metaMaskAccount, selectedWallet]);
+		if (selectedWallet === "CENNZnet")
+			return cennzAccount?.address ? "Connected" : "Connecting";
+
+		if (selectedWallet === "MetaMask")
+			return metaMaskAccount?.address ? "Connected" : "Connecting";
+
+		return "NotConnected";
+	}, [cennzAccount?.address, metaMaskAccount?.address, selectedWallet]);
+
+	console.log({ walletState });
 
 	return (
 		<>
@@ -30,7 +37,7 @@ const WalletButton: React.FC = () => {
 				onClick={() => setWalletOpen(true)}
 			>
 				<div css={styles.walletIcon}>
-					{(walletState === "NotConnected" || !selectedWallet) && (
+					{walletState !== "Connected" && (
 						<AccountBalanceWalletIcon css={styles.walletIconImg} />
 					)}
 
@@ -51,17 +58,25 @@ const WalletButton: React.FC = () => {
 				</div>
 
 				<div css={styles.walletState}>
-					{walletState === "Connected" && selectedWallet === "CENNZnet" && (
-						<span>{cennzAccount?.meta?.name?.toUpperCase?.()}</span>
+					{walletState === "Connected" && (
+						<>
+							{selectedWallet === "CENNZnet" && (
+								<span>{cennzAccount?.meta?.name?.toUpperCase?.()}</span>
+							)}
+
+							{selectedWallet === "MetaMask" && (
+								<span>
+									{metaMaskAccount?.address
+										.slice(0, 6)
+										.concat("...", metaMaskAccount?.address.slice(-4))}
+								</span>
+							)}
+						</>
 					)}
-					{walletState === "Connected" && selectedWallet === "MetaMask" && (
-						<span>
-							{metaMaskAccount?.address
-								.slice(0, 6)
-								.concat("...", metaMaskAccount?.address.slice(-4))}
-						</span>
-					)}
-					{!selectedWallet && <span>CONNECT WALLET</span>}
+
+					{walletState === "Connecting" && <span>CONNECTING...</span>}
+
+					{walletState === "NotConnected" && <span>CONNECT WALLET</span>}
 				</div>
 			</div>
 			<WalletModal>

--- a/components/WalletSelect.tsx
+++ b/components/WalletSelect.tsx
@@ -24,34 +24,32 @@ const WalletSelect: VFC = () => {
 
 	return (
 		<div css={styles.modalContent}>
-			<label htmlFor="select wallet">select wallet</label>
+			<h4 css={styles.selectLabel}>Select Wallet</h4>
 			<div css={styles.selectOptions}>
 				<div
 					css={[styles.metaMaskButton, styles.selectOption]}
 					onClick={() => onOptionClick("MetaMask")}
 				>
-					<div css={styles.walletIcon}>
-						<img
-							src={MetaMaskIconSVG.src}
-							alt="CENNZnet Logo"
-							css={styles.selectOptionImg}
-						/>
-					</div>
-					<span>CONNECT METAMASK</span>
+					<img
+						src={MetaMaskIconSVG.src}
+						alt="CENNZnet Logo"
+						css={styles.selectOptionImg}
+					/>
+
+					<span>METAMASK</span>
 				</div>
 				<br />
 				<div
 					css={[styles.cennzButton, styles.selectOption]}
 					onClick={() => onOptionClick("CENNZnet")}
 				>
-					<div css={styles.walletIcon}>
-						<img
-							src={CENNZIconSVG.src}
-							alt="CENNZnet Logo"
-							css={styles.selectOptionImg}
-						/>
-					</div>
-					<span>CONNECT CENNZnet</span>
+					<img
+						src={CENNZIconSVG.src}
+						alt="CENNZnet Logo"
+						css={styles.selectOptionImg}
+					/>
+
+					<span>CENNZnet</span>
 				</div>
 			</div>
 		</div>
@@ -70,15 +68,16 @@ const styles = {
 		box-shadow: 4px 8px 8px rgba(17, 48, 255, 0.1);
 		border-radius: 4px;
 		outline: none;
+		padding: 1.5em;
+	`,
 
-		label {
-			font-weight: bold;
-			font-size: 14px;
-			text-transform: uppercase;
-			margin: 1em 1em 0.5em;
-			display: block;
-			color: ${palette.primary.main};
-		}
+	selectLabel: ({ palette }: Theme) => css`
+		font-weight: bold;
+		text-align: center;
+		text-transform: uppercase;
+		display: block;
+		color: ${palette.primary.main};
+		margin-top: 0;
 	`,
 
 	selectOptions: css`
@@ -132,15 +131,6 @@ const styles = {
 		display: block;
 		width: 28px;
 		height: 28px;
-		position: absolute;
-		top: 50%;
-		transform: translateY(-50%);
-	`,
-
-	walletIcon: css`
-		width: 28px;
-		height: 28px;
 		margin-right: 0.5em;
-		position: relative;
 	`,
 };

--- a/components/shared/SubmitButton.tsx
+++ b/components/shared/SubmitButton.tsx
@@ -1,4 +1,4 @@
-import { ButtonHTMLAttributes, FC, useMemo } from "react";
+import { ButtonHTMLAttributes, FC, useCallback, useMemo } from "react";
 import { css } from "@emotion/react";
 import { Theme } from "@mui/material";
 import MetaMaskSVG from "@/assets/vectors/metamask.svg";
@@ -31,13 +31,26 @@ const SubmitButton: FC<
 		[forceRequireMetaMask, metaMaskAccount]
 	);
 
+	const onConnectWalletClick = useCallback(() => {
+		const innerHeight = window.innerHeight;
+		const scrollHeight = document.body.scrollHeight;
+
+		if (scrollHeight < innerHeight) return setWalletOpen(true);
+
+		window.scrollTo({ top: 0, behavior: "smooth" });
+
+		setTimeout(() => {
+			setWalletOpen(true);
+		}, 500);
+	}, [setWalletOpen]);
+
 	return (
 		<>
 			{!isConnected && (
 				<button
 					type="button"
 					css={[styles.root, styles.walletButton]}
-					onClick={() => setWalletOpen(true)}
+					onClick={onConnectWalletClick}
 				>
 					<AccountBalanceWalletIcon css={styles.brandLogo} />
 					CONNECT WALLET

--- a/components/shared/SubmitButton.tsx
+++ b/components/shared/SubmitButton.tsx
@@ -1,8 +1,8 @@
 import { ButtonHTMLAttributes, FC, useMemo } from "react";
 import { css } from "@emotion/react";
 import { Theme } from "@mui/material";
-import CENNZIconSVG from "@/assets/vectors/cennznet-icon.svg";
 import MetaMaskSVG from "@/assets/vectors/metamask.svg";
+import AccountBalanceWalletIcon from "@mui/icons-material/AccountBalanceWallet";
 import { useMetaMaskWallet } from "@/providers/MetaMaskWalletProvider";
 import { useWalletProvider } from "@/providers/WalletProvider";
 import { useSelectedAccount } from "@/hooks";
@@ -36,14 +36,10 @@ const SubmitButton: FC<
 			{!isConnected && (
 				<button
 					type="button"
-					css={[styles.root, styles.cennzButton]}
+					css={[styles.root, styles.walletButton]}
 					onClick={() => setWalletOpen(true)}
 				>
-					<img
-						src={CENNZIconSVG.src}
-						alt="CENNZnet Logo"
-						css={styles.brandLogo}
-					/>
+					<AccountBalanceWalletIcon css={styles.brandLogo} />
 					CONNECT WALLET
 				</button>
 			)}
@@ -115,15 +111,15 @@ const styles = {
 		}
 	`,
 
-	cennzButton: ({ palette }: Theme) => css`
+	walletButton: ({ palette }: Theme) => css`
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;
-		border: 1px solid ${palette.primary.default};
-		color: ${palette.primary.default};
+		border: 1px solid ${palette.primary.main};
+		color: ${palette.primary.main};
 
 		&:hover {
-			background-color: ${palette.primary.default};
+			background-color: ${palette.primary.main};
 			color: white;
 		}
 	`,

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -19,6 +19,7 @@ export { default as useHistoricalWithdrawRequest } from "@/hooks/useHistoricalWi
 export { default as useBeforeUnload } from "@/hooks/useBeforeUnload";
 export { default as useSelectedAccount } from "@/hooks/useSelectedAccount";
 export { default as useUpdateCENNZBalances } from "@/hooks/useUpdateCENNZBalances";
+export { default as useEthereumBalances } from "@/hooks/useEthereumBalances";
 
 export type { TokenInputHook } from "@/hooks/useTokenInput";
 export type { PoolExchangeInfoHook } from "@/hooks/usePoolExchangeInfo";

--- a/hooks/useCENNZBalances.ts
+++ b/hooks/useCENNZBalances.ts
@@ -7,29 +7,29 @@ export default function useCENNZBalances(
 	asset1: CENNZAsset | BridgedEthereumToken,
 	asset2?: CENNZAsset | BridgedEthereumToken
 ): [Balance, Balance] {
-	const { CENNZBalances } = useWalletProvider();
+	const { cennzBalances } = useWalletProvider();
 
 	const [balance1, setBalance1] = useState<Balance>(null);
 	const [balance2, setBalance2] = useState<Balance>(null);
 
 	useEffect(() => {
-		if (!CENNZBalances?.length) {
+		if (!cennzBalances?.length) {
 			setBalance1(null);
 			setBalance2(null);
 			return;
 		}
 
-		const balance1Value = CENNZBalances.find(
+		const balance1Value = cennzBalances.find(
 			(balance) => balance.assetId === asset1.assetId
 		);
 
-		const balance2Value = CENNZBalances.find(
+		const balance2Value = cennzBalances.find(
 			(balance) => balance.assetId === asset2?.assetId
 		);
 
 		setBalance1(balance1Value?.value || null);
 		setBalance2(balance2Value?.value || null);
-	}, [CENNZBalances, asset1?.assetId, asset2?.assetId]);
+	}, [cennzBalances, asset1?.assetId, asset2?.assetId]);
 
 	return [balance1, balance2];
 }

--- a/hooks/useDepositRequest.ts
+++ b/hooks/useDepositRequest.ts
@@ -27,7 +27,7 @@ export default function useDepositRequest(): () => Promise<void> {
 		setTxPending,
 		setTxSuccess,
 		setTxFailure,
-		updateMetaMaskBalances,
+		updateEthereumBalances,
 		transferMetaMaskAddress,
 	} = useBridge();
 
@@ -77,7 +77,7 @@ export default function useDepositRequest(): () => Promise<void> {
 				)
 					.then(() => {
 						setTrValue("");
-						updateMetaMaskBalances();
+						updateEthereumBalances();
 						updateCENNZBalances();
 						setTxSuccess({
 							transferValue: transferAmount,
@@ -105,7 +105,7 @@ export default function useDepositRequest(): () => Promise<void> {
 		transferCENNZAddress,
 		transferMetaMaskAddress,
 		metaMaskWallet,
-		updateMetaMaskBalances,
+		updateEthereumBalances,
 		updateCENNZBalances,
 		extension,
 		setTxIdle,

--- a/hooks/useEthereumBalances.ts
+++ b/hooks/useEthereumBalances.ts
@@ -3,7 +3,7 @@ import { BridgedEthereumToken, EthereumToken } from "@/types";
 import { Balance, fetchEthereumBalance } from "@/utils";
 import { useEffect, useMemo, useState } from "react";
 
-export default function useMetaMaskBalances(
+export default function useEthereumBalances(
 	token1: EthereumToken | BridgedEthereumToken,
 	token2?: EthereumToken | BridgedEthereumToken
 ): [Balance, Balance, () => void] {

--- a/hooks/useEthereumBalances.ts
+++ b/hooks/useEthereumBalances.ts
@@ -15,13 +15,11 @@ export default function useEthereumBalances(
 		if (!wallet || !selectedAccount?.address) return;
 
 		return async () => {
-			setBalance1(null);
 			fetchEthereumBalance(wallet, selectedAccount.address, token1).then(
 				setBalance1
 			);
 
 			if (token2) {
-				setBalance2(null);
 				fetchEthereumBalance(wallet, selectedAccount.address, token2).then(
 					setBalance2
 				);

--- a/hooks/useHistoricalWithdrawRequest.ts
+++ b/hooks/useHistoricalWithdrawRequest.ts
@@ -21,7 +21,7 @@ export default function useHistoricalWithdrawRequest(): (
 		setTxPending,
 		setTxSuccess,
 		setTxFailure,
-		updateMetaMaskBalances,
+		updateEthereumBalances,
 		updateUnclaimedWithdrawals,
 	} = useBridge();
 	const { api } = useCENNZApi();
@@ -65,7 +65,7 @@ export default function useHistoricalWithdrawRequest(): (
 
 						withdrawTx.on("txSucceeded", () => {
 							setTrValue("");
-							updateMetaMaskBalances();
+							updateEthereumBalances();
 							updateCENNZBalances();
 							updateUnclaimedWithdrawals();
 							setTxSuccess({
@@ -103,7 +103,7 @@ export default function useHistoricalWithdrawRequest(): (
 			extension,
 			api,
 			metaMaskWallet,
-			updateMetaMaskBalances,
+			updateEthereumBalances,
 			updateCENNZBalances,
 			setTxSuccess,
 			setTxFailure,

--- a/hooks/useMetaMaskBalances.ts
+++ b/hooks/useMetaMaskBalances.ts
@@ -1,6 +1,6 @@
 import { useMetaMaskWallet } from "@/providers/MetaMaskWalletProvider";
 import { BridgedEthereumToken, EthereumToken } from "@/types";
-import { Balance, fetchMetaMaskBalance } from "@/utils";
+import { Balance, fetchEthereumBalance } from "@/utils";
 import { useEffect, useMemo, useState } from "react";
 
 export default function useMetaMaskBalances(
@@ -16,13 +16,13 @@ export default function useMetaMaskBalances(
 
 		return async () => {
 			setBalance1(null);
-			fetchMetaMaskBalance(wallet, selectedAccount.address, token1).then(
+			fetchEthereumBalance(wallet, selectedAccount.address, token1).then(
 				setBalance1
 			);
 
 			if (token2) {
 				setBalance2(null);
-				fetchMetaMaskBalance(wallet, selectedAccount.address, token2).then(
+				fetchEthereumBalance(wallet, selectedAccount.address, token2).then(
 					setBalance2
 				);
 			}

--- a/hooks/useWithdrawRequest.ts
+++ b/hooks/useWithdrawRequest.ts
@@ -26,7 +26,7 @@ export default function useWithdrawRequest(): () => Promise<void> {
 		setTxPending,
 		setTxSuccess,
 		setTxFailure,
-		updateMetaMaskBalances,
+		updateEthereumBalances,
 		updateUnclaimedWithdrawals,
 	} = useBridge();
 	const { api } = useCENNZApi();
@@ -112,7 +112,7 @@ export default function useWithdrawRequest(): () => Promise<void> {
 
 						withdrawTx.on("txSucceeded", () => {
 							setTrValue("");
-							updateMetaMaskBalances();
+							updateEthereumBalances();
 							updateCENNZBalances();
 							setTxSuccess({
 								transferValue: transferAmount,
@@ -129,7 +129,7 @@ export default function useWithdrawRequest(): () => Promise<void> {
 						});
 
 						withdrawTx.on("txCancelled", () => {
-							updateMetaMaskBalances();
+							updateEthereumBalances();
 							updateCENNZBalances();
 							updateUnclaimedWithdrawals();
 							setTxIdle();
@@ -161,7 +161,7 @@ export default function useWithdrawRequest(): () => Promise<void> {
 		cennzWallet?.signer,
 		setTxIdle,
 		setTxFailure,
-		updateMetaMaskBalances,
+		updateEthereumBalances,
 		updateCENNZBalances,
 		setTxSuccess,
 		updateUnclaimedWithdrawals,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "lint": "next lint",
     "test": "jest",
-    "prettier-format": "prettier --config .prettierrc.json ./ --write"
+    "format": "prettier --config .prettierrc.json ./ --write"
   },
   "dependencies": {
     "@cennznet/api": "^2.1.1-alpha.2",

--- a/providers/BridgeProvider.tsx
+++ b/providers/BridgeProvider.tsx
@@ -5,8 +5,8 @@ import {
 	TokenInputHook,
 	TxStatusHook,
 	useSelectedAccount,
+	useEthereumBalances,
 } from "@/hooks";
-import useMetaMaskBalances from "@/hooks/useMetaMaskBalances";
 import {
 	BridgeAction,
 	BridgedEthereumToken,
@@ -108,7 +108,7 @@ const BridgeProvider: FC<BridgeProviderProps> = ({
 		) || ethAsset;
 
 	const [metaMaskBalance, , updateMetaMaskBalances] =
-		useMetaMaskBalances(transferAsset);
+		useEthereumBalances(transferAsset);
 
 	useEffect(() => {
 		const setTransferSelectTokenId = transferSelect.setTokenId;

--- a/providers/BridgeProvider.tsx
+++ b/providers/BridgeProvider.tsx
@@ -46,8 +46,8 @@ interface BridgeContextType extends TxStatusHook {
 	transferMetaMaskAddress: string;
 	setTransferMetaMaskAddress: Dispatch<SetStateAction<string>>;
 
-	metaMaskBalance: Balance;
-	updateMetaMaskBalances: () => void;
+	ethereumBalance: Balance;
+	updateEthereumBalances: () => void;
 
 	advancedExpanded: boolean;
 	setAdvancedExpanded: Dispatch<SetStateAction<boolean>>;
@@ -107,7 +107,7 @@ const BridgeProvider: FC<BridgeProviderProps> = ({
 			(token) => token.address === transferSelect.tokenId
 		) || ethAsset;
 
-	const [metaMaskBalance, , updateMetaMaskBalances] =
+	const [ethereumBalance, , updateEthereumBalances] =
 		useEthereumBalances(transferAsset);
 
 	useEffect(() => {
@@ -146,8 +146,8 @@ const BridgeProvider: FC<BridgeProviderProps> = ({
 				transferMetaMaskAddress,
 				setTransferMetaMaskAddress,
 
-				metaMaskBalance,
-				updateMetaMaskBalances,
+				ethereumBalance,
+				updateEthereumBalances,
 
 				advancedExpanded,
 				setAdvancedExpanded,

--- a/providers/CENNZWalletProvider.tsx
+++ b/providers/CENNZWalletProvider.tsx
@@ -36,7 +36,7 @@ export default function CENNZWalletProvider({
 	const { promptInstallExtension, getInstalledExtension, accounts } =
 		useCENNZExtension();
 	const [wallet, setWallet] = useState<InjectedExtension>(null);
-	const [CENNZAccount, setCENNZAccount] =
+	const [cennzAccount, setCENNZAccount] =
 		useState<InjectedAccountWithMeta>(null);
 
 	const updateCENNZBalances = useUpdateCENNZBalances();
@@ -108,7 +108,7 @@ export default function CENNZWalletProvider({
 	return (
 		<CENNZWalletContext.Provider
 			value={{
-				selectedAccount: CENNZAccount,
+				selectedAccount: cennzAccount,
 				wallet,
 				connectWallet,
 				disconnectWallet,

--- a/providers/WalletProvider.tsx
+++ b/providers/WalletProvider.tsx
@@ -21,7 +21,7 @@ interface WalletContextType {
 	connectedChain: ChainOption;
 	setConnectedChain: (chain: ChainOption) => void;
 
-	CENNZBalances: CENNZAssetBalance[];
+	cennzBalances: CENNZAssetBalance[];
 	setCENNZBalances: Dispatch<SetStateAction<CENNZAssetBalance[]>>;
 }
 
@@ -35,7 +35,7 @@ const WalletProvider: FC<WalletProviderProps> = ({ children }) => {
 	const [walletOpen, setWalletOpen] = useState<boolean>(false);
 	const [selectedWallet, setSelectedWallet] = useState<WalletOption>();
 	const [connectedChain, setConnectedChain] = useState<ChainOption>();
-	const [CENNZBalances, setCENNZBalances] = useState<CENNZAssetBalance[]>(null);
+	const [cennzBalances, setCENNZBalances] = useState<CENNZAssetBalance[]>(null);
 
 	const updateConnectedChain = (chainId: string) => {
 		if (chainId === CENNZ_METAMASK_NETWORK.chainId)
@@ -76,7 +76,7 @@ const WalletProvider: FC<WalletProviderProps> = ({ children }) => {
 				connectedChain,
 				setConnectedChain,
 
-				CENNZBalances,
+				cennzBalances,
 				setCENNZBalances,
 			}}
 		>

--- a/tests/fetchEthereumBalance.test.ts
+++ b/tests/fetchEthereumBalance.test.ts
@@ -1,4 +1,4 @@
-import fetchMetaMaskBalance from "@/utils/fetchMetaMaskBalance";
+import fetchEthereumBalance from "@/utils/fetchEthereumBalance";
 import { BigNumber } from "ethers";
 import GenericERC20Token from "@/artifacts/GenericERC20Token.json";
 import { Balance } from "@/utils";
@@ -7,7 +7,7 @@ const { blockchain, provider, mock } = global.getWeb3MockForTest();
 const { cennzAsset, ethAsset } = global.getEthereumAssetsForTest();
 const testingAccount = global.getEthereumTestingAccount();
 
-describe("fetchMetaMaskBalance", () => {
+describe("fetchEthereumBalance", () => {
 	it("returns expected value ETH", async () => {
 		mock({
 			blockchain,
@@ -16,7 +16,7 @@ describe("fetchMetaMaskBalance", () => {
 				return: BigNumber.from(1),
 			},
 		});
-		const balance = await fetchMetaMaskBalance(
+		const balance = await fetchEthereumBalance(
 			provider,
 			testingAccount,
 			ethAsset
@@ -37,7 +37,7 @@ describe("fetchMetaMaskBalance", () => {
 				return: BigNumber.from(1),
 			},
 		});
-		const balance = await fetchMetaMaskBalance(
+		const balance = await fetchEthereumBalance(
 			provider,
 			testingAccount,
 			cennzAsset

--- a/tests/isCENNZAddress.test.ts
+++ b/tests/isCENNZAddress.test.ts
@@ -1,11 +1,11 @@
 import isCENNZAddress from "@/utils/isCENNZAddress";
 
-const CENNZAccount = global.getCENNZTestingAccount();
+const cennzAccount = global.getCENNZTestingAccount();
 const ethereumAccount = global.getEthereumTestingAccount();
 
 describe("isCENNZAddress", () => {
 	it("returns true if CENNZ address", () => {
-		const isCENNZ = isCENNZAddress(CENNZAccount);
+		const isCENNZ = isCENNZAddress(cennzAccount);
 
 		expect(isCENNZ).toBe(true);
 	});

--- a/tests/isEthereumAddress.test.ts
+++ b/tests/isEthereumAddress.test.ts
@@ -1,7 +1,7 @@
 import isEthereumAddress from "@/utils/isEthereumAddress";
 
 const ethereumAccount = global.getEthereumTestingAccount();
-const CENNZAccount = global.getCENNZTestingAccount();
+const cennzAccount = global.getCENNZTestingAccount();
 
 describe("isEthereumAddress", () => {
 	it("returns true if Ethereum address", () => {
@@ -10,7 +10,7 @@ describe("isEthereumAddress", () => {
 		expect(isEthereum).toBe(true);
 	});
 	it("returns false if not Ethereum address", () => {
-		const isEthereum = isEthereumAddress(CENNZAccount);
+		const isEthereum = isEthereumAddress(cennzAccount);
 
 		expect(isEthereum).toBe(false);
 	});

--- a/utils/fetchEthereumBalance.ts
+++ b/utils/fetchEthereumBalance.ts
@@ -1,12 +1,12 @@
 import { ETH_TOKEN_ADDRESS } from "@/constants";
-import { EthereumToken, MetaMaskAccount } from "@/types";
+import { EthereumToken } from "@/types";
 import { Balance } from "@/utils";
 import { BigNumber, ethers } from "ethers";
 import GenericERC20TokenAbi from "@/artifacts/GenericERC20Token.json";
 
 export default async function fetchEthereumBalance(
 	provider: ethers.providers.Web3Provider,
-	accountAddress: MetaMaskAccount["address"],
+	accountAddress: string,
 	token: EthereumToken
 ): Promise<Balance> {
 	if (token.address === ETH_TOKEN_ADDRESS) {

--- a/utils/fetchEthereumBalance.ts
+++ b/utils/fetchEthereumBalance.ts
@@ -4,7 +4,7 @@ import { Balance } from "@/utils";
 import { BigNumber, ethers } from "ethers";
 import GenericERC20TokenAbi from "@/artifacts/GenericERC20Token.json";
 
-export default async function fetchMetaMaskBalance(
+export default async function fetchEthereumBalance(
 	provider: ethers.providers.Web3Provider,
 	accountAddress: MetaMaskAccount["address"],
 	token: EthereumToken

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -16,7 +16,7 @@ export { default as getAddLiquidityExtrinsic } from "@/utils/getAddLiquidityExtr
 export { default as getRemoveLiquidityExtrinsic } from "@/utils/getRemoveLiquidityExtrinsic";
 export { default as Balance } from "@/utils/Balance";
 export { default as ensureEthereumChain } from "@/utils/ensureEthereumChain";
-export { default as fetchMetaMaskBalance } from "@/utils/fetchMetaMaskBalance";
+export { default as fetchEthereumBalance } from "@/utils/fetchEthereumBalance";
 export {
 	default as fetchBridgeDepositStatus,
 	ensureBridgeDepositActive,


### PR DESCRIPTION
## Description

Several changes here and there since MetaMask integration

## Details

#### Changes

- Rename [`CENNZAccount` -> `cennzAccount`] and [`CENNZBalances` -> `cennzBalances`]
- Update styling / color for `WalletConnect` and `WalletSelect`
- Animate the balances list when switching account in MetaMask
- Rename [`fetchMetaMaskBalance` -> `fetchEthereumBalance`], [`useMetaMaskBalances` -> `useEthereumBalances`] and [`metaMaskBalance` to `ethereumBalance`] to make clear distinction between wallet and network

#### Fixes

- Balances are not fetched when first open the wallet
- `WalletButton` flash of empty label state (re-introducing the `Connecting` state)
- Jumping issue when fetching balances from Ethereum