### PR TITLE
update `pool` to use `useSelectedAccount`

### DIFF
--- a/components/PoolStats.tsx
+++ b/components/PoolStats.tsx
@@ -4,9 +4,12 @@ import { VFC } from "react";
 import { LinearProgress, Tooltip, Theme } from "@mui/material";
 import { usePool } from "@/providers/PoolProvider";
 import { Balance } from "@/utils";
-import { usePoolGasFee, usePoolCoreAssetValue } from "@/hooks";
+import {
+	usePoolGasFee,
+	usePoolCoreAssetValue,
+	useSelectedAccount,
+} from "@/hooks";
 import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
-import { useCENNZWallet } from "@/providers/CENNZWalletProvider";
 
 interface PoolStatsProps {}
 
@@ -40,7 +43,7 @@ const PoolStats: VFC<IntrinsicElements["div"] & PoolStatsProps> = (props) => {
 
 	const { coreAssetValue } = usePoolCoreAssetValue("1");
 
-	const { selectedAccount } = useCENNZWallet();
+	const selectedAccount = useSelectedAccount();
 
 	return (
 		<div {...props} css={styles.root}>
@@ -78,7 +81,7 @@ const PoolStats: VFC<IntrinsicElements["div"] & PoolStatsProps> = (props) => {
 						<span>
 							{`${tradeAssetReserve.toBalance({
 								withSymbol: true,
-							})} + ${coreAssetReserve.toBalance({ withSymbol: true })}`}
+							})} + ${coreAssetReserve?.toBalance({ withSymbol: true })}`}
 						</span>
 					)}
 					{tradeAssetReserve === null && <span>+</span>}

--- a/hooks/usePoolUserInfo.ts
+++ b/hooks/usePoolUserInfo.ts
@@ -1,8 +1,8 @@
 import { useCENNZApi } from "@/providers/CENNZApiProvider";
-import { useCENNZWallet } from "@/providers/CENNZWalletProvider";
 import { useCallback, useEffect, useState } from "react";
 import { fetchPoolUserInfo } from "@/utils";
 import { CENNZAsset, PoolUserInfo } from "@/types";
+import { useSelectedAccount } from "@/hooks";
 
 export interface PoolUserInfoHook {
 	userInfo: PoolUserInfo;
@@ -14,10 +14,11 @@ export default function usePoolUserInfo(
 	tradeAsset: CENNZAsset,
 	coreAsset: CENNZAsset
 ): PoolUserInfoHook {
-	const { selectedAccount } = useCENNZWallet();
 	const { api } = useCENNZApi();
 	const [userInfo, setUserInfo] = useState<PoolUserInfo>(null);
 	const [loading, setLoading] = useState<boolean>(true);
+
+	const selectedAccount = useSelectedAccount();
 
 	const updatePoolUserInfo = useCallback(async () => {
 		if (!api) return;


### PR DESCRIPTION
## Description

 - fix `PoolStats` & `PoolAssetsPair` to enable withdrawal of liquidity via MetaMask and to show `Your Liquidity`
 - closes #190